### PR TITLE
fix: Erweiterungen unter Windows nativ installieren (Hub 1.3.33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Nach dem Neustart erscheint **AIIANER** in der Seitenleiste beziehungsweise als
 Dashboard-Reiter. Die weiteren Komponenten installierst du dort mit den jeweiligen
 Buttons.
 
+### Windows
+
+Windows ist ein gleichwertiger Weg – seit 1.3.33 auch beim Installieren. Der
+Marktplatz spielt „Deutsche Sprache“, „Bot-Modus auf Deutsch“,
+„Gruppenchat-Grenzen“ und „AIIANER Backup“ dort nativ mit dem Python ein, das
+Hermes ohnehin mitbringt. Eine Bash (Git-Bash, MSYS2, WSL) ist dafür **nicht**
+nötig.
+
+Kommst du von 1.3.32 oder älter und die Installation endete mit
+`/bin/bash: C:\Users\...\install.sh: No such file or directory`: zuerst im
+Marktplatz den **AIIANER EXTENSION HUB** aktualisieren, danach die gewünschte
+Komponente. Das Hub-Update selbst war von dem Fehler nicht betroffen.
+
+Nur der **EU-Router** bringt weiter einen Bash-Installer mit. Fehlt eine Bash,
+sagt der Marktplatz das vorher und nennt
+[Git for Windows](https://git-scm.com/download/win) als Abhilfe, statt beim
+Klick in einen Fehler zu laufen.
+
 ## Update und Entfernen
 
 Nach jeder Installation, jedem Update und jeder Deinstallation Hermes **vollständig beenden und neu starten**. Ein Gateway-Neustart oder ein Plugin-Reload reicht für die sichtbare Desktop-Oberfläche nicht zuverlässig aus.

--- a/catalog.json
+++ b/catalog.json
@@ -1,12 +1,12 @@
 {
   "catalogVersion": "1",
-  "updated": "2026-09-10",
+  "updated": "2026-09-12",
   "source": "https://github.com/oliverhees/aiianer-hermes-extensions",
   "components": [
     {
       "id": "aiianer-hub",
       "name": "AIIANER EXTENSION HUB",
-      "version": "1.3.32",
+      "version": "1.3.33",
       "kind": "plugin",
       "premium": false,
       "summary": "Der Marktplatz selbst. Aktualisiert Oberfläche, Desktop-Plugin, Backend und Wächter in einem Schritt.",

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "AIIANER EXTENSION HUB",
   "description": "Deutsche Erweiterungen installieren und aktuell halten",
   "icon": "Package",
-  "version": "1.3.32",
+  "version": "1.3.33",
   "tab": {
     "path": "/aiianer",
     "position": "after:skills"

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import gzip
 import json
 import re
 import os
@@ -189,6 +190,21 @@ def _verfuegbar(comp_id: str) -> tuple:
                 "Hermes' source folder is not where it is expected "
                 f"({I18N_DIR}). Without it the language cannot be installed.",
             )
+
+    # Ein Knopf, der zuverlaessig in einen 500er laeuft, ist schlimmer als
+    # gar kein Knopf: Komponenten, fuer die es nur den Bash-Weg gibt, brauchen
+    # auf Windows eine echte Bash (Git-Bash oder MSYS2).
+    if _ist_windows() and _braucht_bash(comp_id) and _bash_binaer() is None:
+        return (
+            False,
+            "Diese Komponente bringt einen Bash-Installer mit, auf diesem "
+            "Rechner ist aber keine Bash erreichbar. Installiere Git for "
+            "Windows (https://git-scm.com/download/win) und starte Hermes "
+            "danach neu.",
+            "This component ships a bash installer, but no bash is reachable "
+            "on this machine. Install Git for Windows "
+            "(https://git-scm.com/download/win), then restart Hermes.",
+        )
     return (True, "", "")
 
 
@@ -747,6 +763,287 @@ async def health() -> dict:
     return _guard().check_all()
 
 
+# ------------------------------------------------- Installer je Plattform
+
+# Die Installer der Erweiterungen sind Bash-Skripte. Auf Linux und macOS ist
+# das der kurze Weg. Auf Windows ist es ein Irrweg, aus zwei Gruenden:
+#
+#   1. Dort gibt es meist ueberhaupt keine Bash. Der Aufruf endet dann in
+#      einem nackten WinError 2 und die Oberflaeche zeigt einen 500er.
+#   2. Und wenn doch eine da ist (Git-Bash, MSYS2), dann bekommt sie von
+#      Python einen nativen Windows-Pfad. Fuer eine Bash ist der Backslash
+#      ein Fluchtzeichen, also wird aus
+#      C:\Users\...\Temp\tmp1234\extensions\german-language\install.sh
+#      beim Einlesen C:Users...install.sh - und sie meldet
+#      "No such file or directory" fuer eine Datei, die sehr wohl da liegt.
+#      Genau dieser Fehler kam aus der Community (Windows 11, MSYS2-Bash).
+#
+# Darum bekommt Windows einen eigenen, nativen Weg: dieselben Schritte in
+# Python, mit sys.executable als Interpreter fuer die apply-*.py-Patcher.
+# Kein bash, kein python3, kein gzip, kein cp im PATH noetig. Genau so
+# arbeitet der Waechter (guard_check.repair_*) schon heute - nur der Knopf
+# im Marktplatz tat es noch nicht.
+#
+# WICHTIG: Ein nativer Installer unten und die install.sh seiner Erweiterung
+# muessen dieselben Schritte tun. Wer das eine aendert, aendert auch das
+# andere. tests/test_plugin_api_windows_install.py haelt die Schritte fest.
+
+
+def _ist_windows() -> bool:
+    """Eine Stelle fuer die Plattformfrage. So ist der Windows-Weg auch auf
+    einem Linux-Rechner pruefbar, ohne os.name im ganzen Prozess zu biegen."""
+    return os.name == "nt"
+
+
+def _posix_pfad(pfad) -> str:
+    """Pfad in der Schreibweise, die eine Git-/MSYS2-Bash versteht.
+
+    'C:/Users/...' loest eine MSYS2-Bash korrekt auf, 'C:\\Users\\...' nicht."""
+    return str(pfad).replace("\\", "/")
+
+
+def _bash_binaer() -> str | None:
+    """Welche Bash darf einen Installer ausfuehren?
+
+    Auf Windows ist shutil.which("bash") eine Falle: es findet zuerst
+    C:\\Windows\\System32\\bash.exe, den Starter fuer das Linux-Subsystem. Der
+    sieht ein voellig anderes Dateisystem - der Installer wuerde scheinbar
+    durchlaufen und am Hermes der Nutzerin nichts aendern. Deshalb auf
+    Windows nur Git-Bash und MSYS2, und System32 ausdruecklich nicht."""
+    gefunden = shutil.which("bash")
+    if not _ist_windows():
+        # Wenn PATH mager ist (Dienst-Umgebung), liegt sie trotzdem dort.
+        if gefunden is None and Path("/bin/bash").is_file():
+            return "/bin/bash"
+        return gefunden
+    kandidaten: list[str] = []
+    if gefunden and Path(gefunden).parent.name.lower() != "system32":
+        kandidaten.append(gefunden)
+    for basis in (
+        os.environ.get("ProgramFiles", r"C:\Program Files"),
+        os.environ.get("ProgramFiles(x86)", ""),
+        os.environ.get("LOCALAPPDATA", ""),
+    ):
+        if basis:
+            kandidaten.append(str(Path(basis) / "Git" / "bin" / "bash.exe"))
+            kandidaten.append(str(Path(basis) / "Programs" / "Git" / "bin" / "bash.exe"))
+    kandidaten.append(r"C:\msys64\usr\bin\bash.exe")
+    for kandidat in kandidaten:
+        if Path(kandidat).is_file():
+            return kandidat
+    return None
+
+
+def _installer_umgebung() -> dict:
+    """Umgebung fuer einen Bash-Installer.
+
+    HERMES_HOME und HERMES_AGENT_DIR in Posix-Schreibweise: sonst setzt die
+    Bash daraus Pfade mit Backslashes zusammen und greift ins Leere. Auf
+    Linux und macOS ist das eine Kopie derselben Werte, die auch hermes_home()
+    liefert - dort aendert sich also nichts."""
+    env = dict(os.environ)
+    env["HERMES_HOME"] = _posix_pfad(HERMES_HOME)
+    env["HERMES_AGENT_DIR"] = _posix_pfad(AGENT_DIR)
+    return env
+
+
+def _ext_store(comp_id: str) -> Path:
+    """Dauerablage der Payload - dieselbe Stelle, die auch die install.sh
+    benutzen ($HERMES_HOME/aiianer-extensions/<id>)."""
+    return HERMES_HOME / "aiianer-extensions" / comp_id
+
+
+def _protokoll(text: str) -> list[str]:
+    return [z for z in (text or "").splitlines() if z.strip()]
+
+
+def _run_patcher(patcher: Path, argumente: list[str], cwd: Path) -> list[str]:
+    """Fuehrt einen apply-*.py-Patcher mit DEM Python aus, das schon laeuft.
+
+    Kein "python3" im PATH noetig - auf Windows gibt es das naemlich nicht."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(patcher), *argumente],
+            capture_output=True, text=True, timeout=180, cwd=str(cwd), shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise HTTPException(status_code=500, detail=f"{patcher.name}: {exc}") from exc
+    if proc.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=(proc.stderr or proc.stdout or f"{patcher.name} fehlgeschlagen")[-800:],
+        )
+    return _protokoll(proc.stdout)
+
+
+def _run_bash_installer(comp_id: str, src: Path) -> list[str]:
+    installer = src / "install.sh"
+    if not installer.is_file():
+        raise HTTPException(status_code=500, detail=f"{comp_id} hat kein install.sh")
+    with contextlib.suppress(OSError):
+        os.chmod(installer, 0o755)
+    bash = _bash_binaer()
+    if bash is None:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                f"{comp_id} braucht eine Bash, auf diesem Rechner ist keine "
+                "erreichbar. Unter Windows hilft Git for Windows "
+                "(https://git-scm.com/download/win), danach Hermes neu starten."
+            ),
+        )
+    # Der Dateiname wird RELATIV uebergeben, der Ordner ueber cwd gesetzt.
+    # Damit sieht die Bash nie einen Windows-Pfad mit Backslashes und kann
+    # ihn auch nicht falsch auflösen.
+    try:
+        proc = subprocess.run(
+            [bash, "./install.sh"],
+            capture_output=True, text=True, timeout=180, cwd=str(src),
+            env=_installer_umgebung(), shell=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise HTTPException(status_code=500, detail=f"{comp_id}: {exc}") from exc
+    if proc.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=(proc.stderr or proc.stdout or "Installation fehlgeschlagen")[-800:],
+        )
+    return _protokoll(proc.stdout)[-12:]
+
+
+def _install_german_native(src: Path) -> list[str]:
+    """Schritte aus extensions/german-language/install.sh, ohne Bash."""
+    quelle = src / "de.ts"
+    if not quelle.is_file():
+        gepackt = src / "de.ts.gz"
+        if not gepackt.is_file():
+            raise HTTPException(
+                status_code=500,
+                detail="Die Sprach-Payload de.ts.gz fehlt im heruntergeladenen Repo.",
+            )
+        with gzip.open(gepackt, "rb") as ein, open(quelle, "wb") as aus:
+            shutil.copyfileobj(ein, aus)
+    store = _ext_store("german-language")
+    store.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(quelle, store / "de.ts")
+    shutil.copy2(src / "apply-de.py", store / "apply-de.py")
+    return _run_patcher(store / "apply-de.py", [str(AGENT_DIR)], store)
+
+
+def _install_bots_native(src: Path) -> list[str]:
+    """Schritte aus extensions/bot-mode-german/install.sh, ohne Bash."""
+    if not BOTS_KATALOG.is_file():
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Nachrichtenkatalog des Bot-Modus nicht gefunden unter "
+                f"{BOTS_KATALOG}. Ist Hermes Desktop installiert und aktuell?"
+            ),
+        )
+    try:
+        verdrahtet = bool(
+            re.search(
+                r"^export type Locale = .*'de'",
+                (I18N_DIR / "types.ts").read_text(errors="ignore"),
+                re.M,
+            )
+        )
+    except OSError:
+        verdrahtet = False
+    if not verdrahtet:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Die deutsche Sprache ist nicht eingerichtet. Der Bot-Modus "
+                "haengt daran: ohne 'de' als gueltige Sprache waere das Buendel "
+                "eingetragen, aber nie auswaehlbar. Zuerst „Deutsche Sprache“ "
+                "installieren."
+            ),
+        )
+    store = _ext_store("bot-mode-german")
+    store.mkdir(parents=True, exist_ok=True)
+    for name in ("de-bots.ts", "apply-bots-de.py"):
+        shutil.copy2(src / name, store / name)
+    return _run_patcher(store / "apply-bots-de.py", [str(AGENT_DIR)], store)
+
+
+def _install_limits_native(src: Path) -> list[str]:
+    """Schritte aus extensions/group-chat-limits/install.sh, ohne Bash."""
+    if not BOTS_ROUNDS.is_file():
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Rundenschleife des Gruppenchats nicht gefunden unter "
+                f"{BOTS_ROUNDS}. Ist Hermes Desktop installiert und aktuell?"
+            ),
+        )
+    store = _ext_store("group-chat-limits")
+    store.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    log: list[str] = []
+    # Beispiel-Konfiguration anlegen, aber niemals eine vorhandene ueberschreiben.
+    konfig = STATE_DIR / "gruppen-grenzen.json"
+    if not konfig.is_file():
+        shutil.copy2(src / "gruppen-grenzen.beispiel.json", konfig)
+        log.append(f"Beispiel-Konfiguration angelegt: {konfig}")
+    for name in ("aiianer-group-limits.ts", "apply-limits.py", "gruppen-grenzen.beispiel.json"):
+        shutil.copy2(src / name, store / name)
+    for name in ("aiianer-group-limits.ts", "apply-limits.py"):
+        shutil.copy2(src / name, STATE_DIR / name)
+    return log + _run_patcher(
+        store / "apply-limits.py", [str(AGENT_DIR), str(STATE_DIR)], store
+    )
+
+
+def _install_backup_native(src: Path) -> list[str]:
+    """Schritte aus extensions/aiianer-backup/install.sh, ohne Bash."""
+    ziel = HERMES_HOME / "scripts" / "aiianer-backup-runner.py"
+    ziel.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src / "backup_runner.py", ziel)
+    with contextlib.suppress(OSError):
+        os.chmod(ziel, 0o755)
+    zustand = STATE_DIR / "backup-state.json"
+    if not zustand.exists():
+        _write_json_atomic(zustand, {
+            "schemaVersion": 1, "enabled": False, "target_dir": "",
+            "schedule": "manual", "retention": {"enabled": False, "keep": 5},
+            "state": "never_run", "lastRun": None, "lastArchive": None,
+            "lastErrorCode": None,
+        })
+    return [
+        "AIIANER Backup installiert. Zielordner im Backups-Tab festlegen; "
+        "keine Uploads in V1."
+    ]
+
+
+# Nur Erweiterungen, deren install.sh nichts anderes tut als Payload ablegen
+# und einen Patcher starten. Der EU-Router laedt einen fremden Installer aus
+# dem Netz nach - den kann und soll dieser Code nicht nachbauen.
+NATIVE_INSTALLER = {
+    "german-language": _install_german_native,
+    "bot-mode-german": _install_bots_native,
+    "group-chat-limits": _install_limits_native,
+    "aiianer-backup": _install_backup_native,
+}
+
+
+def _braucht_bash(comp_id: str) -> bool:
+    """Gibt es fuer diese Komponente nur den Bash-Weg?"""
+    return comp_id not in NATIVE_INSTALLER and comp_id != "aiianer-hub"
+
+
+def _run_extension_installer(comp_id: str, src: Path) -> list[str]:
+    """Auf Windows nativ, wo es einen nativen Weg gibt - sonst per Bash.
+
+    Auf Linux und macOS bleibt der eingespielte Bash-Weg der Standard: er
+    laeuft dort seit Monaten und ist die Fassung, die Nutzer auch von Hand
+    starten."""
+    nativ = NATIVE_INSTALLER.get(comp_id)
+    if nativ is not None and _ist_windows():
+        return nativ(src)
+    return _run_bash_installer(comp_id, src)
+
+
 @router.post("/install")
 async def install(body: dict) -> dict:
     comp_id = (body or {}).get("id", "")
@@ -766,7 +1063,12 @@ async def install(body: dict) -> dict:
 
     previous_version = _local_plugin_version(comp_id, _read_state())
 
-    with tempfile.TemporaryDirectory() as tmp:
+    # Kein TemporaryDirectory-Kontext: unter Windows kann das Aufraeumen an
+    # einer noch gehaltenen Datei scheitern (Virenscanner, Indexdienst). Das
+    # wuerde eine bereits gelungene Installation als 500er ausgeben - der
+    # Nutzer haelt dann sein System fuer kaputt, obwohl alles sitzt.
+    tmp = tempfile.mkdtemp(prefix="aiianer-install-")
+    try:
         root = _download(tmp)
         install_log: list[str]
         if comp_id == "aiianer-hub":
@@ -778,23 +1080,7 @@ async def install(body: dict) -> dict:
                 raise HTTPException(
                     status_code=500, detail=f"{comp_id} fehlt im heruntergeladenen Repo"
                 )
-            installer = src / "install.sh"
-            if not installer.is_file():
-                raise HTTPException(status_code=500, detail=f"{comp_id} hat kein install.sh")
-            os.chmod(installer, 0o755)
-            proc = subprocess.run(
-                ["bash", str(installer)],
-                capture_output=True,
-                text=True,
-                timeout=180,
-                cwd=str(src),
-            )
-            if proc.returncode != 0:
-                raise HTTPException(
-                    status_code=500,
-                    detail=(proc.stderr or proc.stdout or "Installation fehlgeschlagen")[-800:],
-                )
-            install_log = [z for z in (proc.stdout or "").splitlines() if z.strip()][-12:]
+            install_log = _run_extension_installer(comp_id, src)[-12:]
 
             # Sprachdatei zusaetzlich als Quelle sichern, damit der Waechter sie
             # nach einem Hermes-Update erneut einspielen kann.
@@ -804,6 +1090,8 @@ async def install(body: dict) -> dict:
                              "aiianer-group-limits.ts", "apply-limits.py"):
                     if (src / name).is_file():
                         shutil.copy2(src / name, STATE_DIR / name)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
     with _state_lock():
         state = _read_state()

--- a/extensions/bot-mode-german/install.sh
+++ b/extensions/bot-mode-german/install.sh
@@ -46,7 +46,21 @@ fi
 
 mkdir -p "$STORE"
 cp "$HERE/de-bots.ts" "$HERE/apply-bots-de.py" "$STORE/"
-python3 "$STORE/apply-bots-de.py" "$AGENT_DIR"
+# Welches Python? Auf Linux und macOS ist es python3. In einer Git-Bash unter
+# Windows gibt es python3 oft nicht, dort heisst es python oder py. Der
+# Marktplatz umgeht das ganz (er nimmt sein eigenes sys.executable) - wer den
+# Installer von Hand startet, braucht diese Suche.
+PY="${PYTHON:-}"
+if [ -z "$PY" ]; then
+  for kandidat in python3 python py; do
+    if command -v "$kandidat" >/dev/null 2>&1; then PY="$kandidat"; break; fi
+  done
+fi
+if [ -z "$PY" ]; then
+  echo "FEHLER: Kein Python gefunden (python3, python, py). Bitte Python installieren." >&2
+  exit 1
+fi
+"$PY" "$STORE/apply-bots-de.py" "$AGENT_DIR"
 
 echo ""
 echo "Fertig. Hermes Desktop komplett neu starten - beim ersten Start baut die App kurz neu."

--- a/extensions/german-language/install.sh
+++ b/extensions/german-language/install.sh
@@ -27,7 +27,21 @@ fi
 mkdir -p "$STORE"
 cp "$HERE/de.ts" "$HERE/apply-de.py" "$STORE/"
 
-python3 "$STORE/apply-de.py" "$AGENT_DIR"
+# Welches Python? Auf Linux und macOS ist es python3. In einer Git-Bash unter
+# Windows gibt es python3 oft nicht, dort heisst es python oder py. Der
+# Marktplatz umgeht das ganz (er nimmt sein eigenes sys.executable) - wer den
+# Installer von Hand startet, braucht diese Suche.
+PY="${PYTHON:-}"
+if [ -z "$PY" ]; then
+  for kandidat in python3 python py; do
+    if command -v "$kandidat" >/dev/null 2>&1; then PY="$kandidat"; break; fi
+  done
+fi
+if [ -z "$PY" ]; then
+  echo "FEHLER: Kein Python gefunden (python3, python, py). Bitte Python installieren." >&2
+  exit 1
+fi
+"$PY" "$STORE/apply-de.py" "$AGENT_DIR"
 echo ""
 echo "Fertig. Hermes Desktop komplett neu starten - beim ersten Start baut die App kurz neu."
 echo "Sprache umstellen: Settings -> Language -> Deutsch."

--- a/extensions/group-chat-limits/install.sh
+++ b/extensions/group-chat-limits/install.sh
@@ -45,7 +45,21 @@ cp "$HERE/aiianer-group-limits.ts" "$HERE/apply-limits.py" \
    "$HERE/gruppen-grenzen.beispiel.json" "$STORE/"
 cp "$HERE/aiianer-group-limits.ts" "$HERE/apply-limits.py" "$STATE_DIR/"
 
-python3 "$STORE/apply-limits.py" "$AGENT_DIR" "$STATE_DIR"
+# Welches Python? Auf Linux und macOS ist es python3. In einer Git-Bash unter
+# Windows gibt es python3 oft nicht, dort heisst es python oder py. Der
+# Marktplatz umgeht das ganz (er nimmt sein eigenes sys.executable) - wer den
+# Installer von Hand startet, braucht diese Suche.
+PY="${PYTHON:-}"
+if [ -z "$PY" ]; then
+  for kandidat in python3 python py; do
+    if command -v "$kandidat" >/dev/null 2>&1; then PY="$kandidat"; break; fi
+  done
+fi
+if [ -z "$PY" ]; then
+  echo "FEHLER: Kein Python gefunden (python3, python, py). Bitte Python installieren." >&2
+  exit 1
+fi
+"$PY" "$STORE/apply-limits.py" "$AGENT_DIR" "$STATE_DIR"
 
 echo ""
 echo "Fertig. Hermes Desktop komplett neu starten - beim ersten Start baut die App kurz neu."

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: aiianer-hub
 manifest_version: 1
-version: 1.3.32
+version: 1.3.33
 description: >
   AIIANER Marktplatz. Installiert und aktualisiert die deutschen
   Hermes-Erweiterungen und haelt die Sprachdatei nach jedem Update aktuell.

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "tagName": "v1.3.33",
+      "name": "v1.3.33 · Installation unter Windows repariert",
+      "publishedAt": "2026-09-12T08:00:00Z",
+      "body": "Der Installer der Erweiterungen lief unter Windows ins Leere: das Backend rief bash mit einem Windows-Pfad auf, und für eine Bash ist der Backslash ein Fluchtzeichen - sie meldete \"No such file or directory\" für eine Datei, die sehr wohl da lag. Rechner ohne Bash bekamen ohnehin nur einen 500er. Windows installiert Deutsche Sprache, Bot-Modus, Gruppenchat-Grenzen und Backup jetzt nativ in Python, genau wie der Wächter es nach einem Hermes-Update schon immer tat - ohne bash, ohne python3 im PATH. Wo es weiter einen Bash-Installer gibt, bekommt die Bash nur noch einen relativen Dateinamen und Pfade in Posix-Schreibweise; fehlt sie ganz, sagt der Marktplatz das vorher statt nach dem Klick."
+    },
+    {
       "tagName": "v1.3.32",
       "name": "v1.3.32 · Optionale Host-API abgesichert",
       "publishedAt": "2026-09-11T02:30:00Z",
@@ -114,7 +120,6 @@
       "url": "https://github.com/oliverhees/aiianer-hermes-extensions/releases/tag/v1.3.16"
     },
     {
-
       "tagName": "v1.3.15",
       "name": "v1.3.15 · Beta-Feedback und Marktplatz-Auftritt",
       "publishedAt": "2026-09-10T16:30:00Z",

--- a/tests/test_plugin_api_hub_install.py
+++ b/tests/test_plugin_api_hub_install.py
@@ -274,8 +274,28 @@ class HubCatalogUpdateStatusTest(unittest.TestCase):
 
         hub = next(component for component in result["components"] if component["id"] == "aiianer-hub")
         self.assertEqual(hub["installed"], "1.3.12")
-        self.assertEqual(hub["version"], "1.3.32")
+        self.assertEqual(hub["version"], "1.3.33")
         self.assertEqual(hub["status"], "outdated")
+
+
+class VersionKonsistenzTest(unittest.TestCase):
+    """plugin.yaml, dashboard/manifest.json und catalog.json tragen dieselbe
+    Hub-Version. Laufen sie auseinander, sieht ein Nutzer "aktuell", obwohl
+    sein Hub alt ist - oder umgekehrt."""
+
+    def test_hub_version_is_identical_in_all_three_places(self):
+        katalog = json.loads((REPO_ROOT / "catalog.json").read_text())
+        hub = next(c for c in katalog["components"] if c["id"] == "aiianer-hub")
+        manifest = json.loads((REPO_ROOT / "dashboard" / "manifest.json").read_text())
+        plugin_yaml = (REPO_ROOT / "plugin.yaml").read_text()
+        self.assertEqual(manifest["version"], hub["version"])
+        self.assertIn(f"version: {hub['version']}", plugin_yaml)
+
+    def test_release_notes_mention_the_catalog_version(self):
+        katalog = json.loads((REPO_ROOT / "catalog.json").read_text())
+        hub = next(c for c in katalog["components"] if c["id"] == "aiianer-hub")
+        tags = [r["tagName"] for r in json.loads((REPO_ROOT / "releases.json").read_text())["releases"]]
+        self.assertIn(f"v{hub['version']}", tags)
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_api_windows_install.py
+++ b/tests/test_plugin_api_windows_install.py
@@ -1,0 +1,429 @@
+"""Der Marktplatz-Knopf muss auch auf Windows installieren.
+
+Hintergrund: Bis 1.3.32 rief das Backend ["bash", "C:\\...\\install.sh"] auf.
+Auf Windows ohne Bash endete das in einem 500er, und mit Git-/MSYS2-Bash
+ebenfalls - fuer eine Bash ist der Backslash ein Fluchtzeichen, sie meldete
+"No such file or directory" fuer eine Datei, die sehr wohl da lag.
+
+Diese Tests halten beides fest: den nativen Windows-Weg (kein bash, kein
+python3) und die Bash-Aufrufe, die es weiter gibt (relativer Skriptname,
+Pfade in Posix-Schreibweise).
+"""
+from __future__ import annotations
+
+import asyncio
+import gzip
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+API_PATH = REPO_ROOT / "dashboard" / "plugin_api.py"
+
+
+def load_api_module():
+    spec = importlib.util.spec_from_file_location("aiianer_plugin_api_win_test", API_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Ein Patcher-Ersatz: schreibt seine Argumente mit, damit der Test sieht,
+# WIE er aufgerufen wurde - und legt eine Spur, damit er nachweislich lief.
+PATCHER_STUB = """import json, sys
+from pathlib import Path
+Path(__file__).with_name("patcher-lief.json").write_text(
+    json.dumps({"argv": sys.argv[1:], "cwd": str(Path.cwd()), "exe": sys.executable})
+)
+print("Patcher gelaufen")
+"""
+
+
+def hermes_heim(api, wurzel: Path) -> Path:
+    """Verdrahtet das Modul auf ein Test-Hermes um."""
+    heim = wurzel / "hermes-home"
+    agent = heim / "hermes-agent"
+    i18n = agent / "apps" / "desktop" / "src" / "i18n"
+    bots = agent / "apps" / "desktop" / "src" / "plugins" / "hermes-bots"
+    i18n.mkdir(parents=True)
+    bots.mkdir(parents=True)
+    (i18n / "types.ts").write_text("export type Locale = 'en' | 'de'\n")
+    (bots / "i18n.ts").write_text("export const MESSAGES = {}\n")
+    (bots / "group-rounds.ts").write_text("export const MAX_ROUNDS = 3\n")
+    api.HERMES_HOME = heim
+    api.PLUGINS = heim / "plugins"
+    api.STATE_DIR = heim / "aiianer"
+    api.EXT_STORE = heim / "aiianer-extensions"
+    api.AGENT_DIR = agent
+    api.I18N_DIR = i18n
+    api.BOTS_DIR = bots
+    api.BOTS_KATALOG = bots / "i18n.ts"
+    api.BOTS_ROUNDS = bots / "group-rounds.ts"
+    return heim
+
+
+class NativeGermanInstallTest(unittest.TestCase):
+    def test_installs_german_without_bash_and_without_python3(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "german-language"
+            src.mkdir(parents=True)
+            with gzip.open(src / "de.ts.gz", "wb") as fh:
+                fh.write(b"export const de = {}\n")
+            (src / "apply-de.py").write_text(PATCHER_STUB)
+
+            # Ein Bash-Aufruf waere hier schon der Fehler von 1.3.32.
+            with mock.patch.object(api, "_ist_windows", return_value=True), mock.patch.object(
+                api, "_run_bash_installer", side_effect=AssertionError("bash darf nicht laufen")
+            ):
+                log = api._run_extension_installer("german-language", src)
+
+            store = heim / "aiianer-extensions" / "german-language"
+            self.assertEqual((store / "de.ts").read_text(), "export const de = {}\n")
+            self.assertTrue((store / "apply-de.py").is_file())
+            # de.ts muss auch in src liegen: /install sichert die Payload von
+            # dort nach ~/.hermes/aiianer/, damit der Waechter sie wiederfindet.
+            self.assertTrue((src / "de.ts").is_file())
+            self.assertIn("Patcher gelaufen", log)
+
+            spur = json.loads((store / "patcher-lief.json").read_text())
+            self.assertEqual(spur["argv"], [str(api.AGENT_DIR)])
+            self.assertEqual(Path(spur["cwd"]), store)
+            self.assertEqual(spur["exe"], sys.executable)
+
+    def test_reports_missing_payload_instead_of_crashing(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "german-language"
+            src.mkdir(parents=True)
+            (src / "apply-de.py").write_text(PATCHER_STUB)
+            with self.assertRaises(api.HTTPException) as fall:
+                api._install_german_native(src)
+            self.assertIn("de.ts.gz", str(fall.exception.detail))
+
+    def test_failing_patcher_becomes_readable_error(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "german-language"
+            src.mkdir(parents=True)
+            with gzip.open(src / "de.ts.gz", "wb") as fh:
+                fh.write(b"export const de = {}\n")
+            (src / "apply-de.py").write_text(
+                "import sys\nprint('FEHLER: Anker weg', file=sys.stderr)\nsys.exit(1)\n"
+            )
+            with self.assertRaises(api.HTTPException) as fall:
+                api._install_german_native(src)
+            self.assertEqual(fall.exception.status_code, 500)
+            self.assertIn("Anker weg", str(fall.exception.detail))
+
+
+class NativeBotsAndLimitsTest(unittest.TestCase):
+    def test_installs_bot_bundle_natively(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "bot-mode-german"
+            src.mkdir(parents=True)
+            (src / "de-bots.ts").write_text("export const deBots = {}\n")
+            (src / "apply-bots-de.py").write_text(PATCHER_STUB)
+
+            api._install_bots_native(src)
+
+            store = heim / "aiianer-extensions" / "bot-mode-german"
+            self.assertTrue((store / "de-bots.ts").is_file())
+            spur = json.loads((store / "patcher-lief.json").read_text())
+            self.assertEqual(spur["argv"], [str(api.AGENT_DIR)])
+
+    def test_bot_bundle_refuses_without_german_locale(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            (api.I18N_DIR / "types.ts").write_text("export type Locale = 'en'\n")
+            src = wurzel / "extensions" / "bot-mode-german"
+            src.mkdir(parents=True)
+            (src / "de-bots.ts").write_text("export const deBots = {}\n")
+            (src / "apply-bots-de.py").write_text(PATCHER_STUB)
+            with self.assertRaises(api.HTTPException) as fall:
+                api._install_bots_native(src)
+            self.assertIn("Deutsche Sprache", str(fall.exception.detail))
+
+    def test_limits_keeps_existing_configuration(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            api.STATE_DIR.mkdir(parents=True)
+            eigen = '{"default": {"maxRounds": 99}}\n'
+            (api.STATE_DIR / "gruppen-grenzen.json").write_text(eigen)
+
+            src = wurzel / "extensions" / "group-chat-limits"
+            src.mkdir(parents=True)
+            (src / "aiianer-group-limits.ts").write_text("export const grenzen = {}\n")
+            (src / "apply-limits.py").write_text(PATCHER_STUB)
+            (src / "gruppen-grenzen.beispiel.json").write_text('{"default": {"maxRounds": 8}}\n')
+
+            api._install_limits_native(src)
+
+            # Eigene Grenzen bleiben stehen.
+            self.assertEqual((api.STATE_DIR / "gruppen-grenzen.json").read_text(), eigen)
+            store = heim / "aiianer-extensions" / "group-chat-limits"
+            self.assertTrue((store / "gruppen-grenzen.beispiel.json").is_file())
+            # Der Waechter braucht Modul und Patcher unter ~/.hermes/aiianer/.
+            self.assertTrue((api.STATE_DIR / "aiianer-group-limits.ts").is_file())
+            self.assertTrue((api.STATE_DIR / "apply-limits.py").is_file())
+            spur = json.loads((store / "patcher-lief.json").read_text())
+            self.assertEqual(spur["argv"], [str(api.AGENT_DIR), str(api.STATE_DIR)])
+
+    def test_limits_seeds_example_configuration_once(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "group-chat-limits"
+            src.mkdir(parents=True)
+            (src / "aiianer-group-limits.ts").write_text("export const grenzen = {}\n")
+            (src / "apply-limits.py").write_text(PATCHER_STUB)
+            (src / "gruppen-grenzen.beispiel.json").write_text('{"default": {"maxRounds": 8}}\n')
+
+            api._install_limits_native(src)
+
+            self.assertEqual(
+                json.loads((api.STATE_DIR / "gruppen-grenzen.json").read_text()),
+                {"default": {"maxRounds": 8}},
+            )
+
+
+class NativeBackupInstallTest(unittest.TestCase):
+    def test_installs_runner_and_seeds_state_once(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            src = wurzel / "extensions" / "aiianer-backup"
+            src.mkdir(parents=True)
+            (src / "backup_runner.py").write_text("# runner\n")
+
+            api._install_backup_native(src)
+
+            runner = heim / "scripts" / "aiianer-backup-runner.py"
+            self.assertEqual(runner.read_text(), "# runner\n")
+            zustand = json.loads((api.STATE_DIR / "backup-state.json").read_text())
+            self.assertFalse(zustand["enabled"])
+            self.assertEqual(zustand["state"], "never_run")
+
+            # Zweiter Lauf darf eine eingerichtete Sicherung nicht zuruecksetzen.
+            zustand["enabled"] = True
+            zustand["target_dir"] = str(wurzel / "ziel")
+            (api.STATE_DIR / "backup-state.json").write_text(json.dumps(zustand))
+            api._install_backup_native(src)
+            self.assertTrue(
+                json.loads((api.STATE_DIR / "backup-state.json").read_text())["enabled"]
+            )
+
+
+class BashAufrufTest(unittest.TestCase):
+    """Wo es weiter per Bash laeuft, darf kein Windows-Pfad hineingehen."""
+
+    def test_passes_relative_script_name_and_posix_paths(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            # Ein Heim, wie Windows es liefert: mit Backslashes.
+            api.HERMES_HOME = Path(r"C:\Users\emanu\AppData\Local\hermes")
+            api.AGENT_DIR = Path(r"C:\Users\emanu\AppData\Local\hermes\hermes-agent")
+            src = wurzel / "extensions" / "eurouter-provider"
+            src.mkdir(parents=True)
+            (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
+
+            gesehen = {}
+
+            def falscher_lauf(argv, **kwargs):
+                gesehen["argv"] = argv
+                gesehen["kwargs"] = kwargs
+                return subprocess.CompletedProcess(argv, 0, "ok\n", "")
+
+            with mock.patch.object(api, "_bash_binaer", return_value="/usr/bin/bash"), \
+                    mock.patch.object(api.subprocess, "run", falscher_lauf):
+                api._run_bash_installer("eurouter-provider", src)
+
+            self.assertEqual(gesehen["argv"], ["/usr/bin/bash", "./install.sh"])
+            self.assertEqual(Path(gesehen["kwargs"]["cwd"]), src)
+            self.assertFalse(gesehen["kwargs"]["shell"])
+            for argument in gesehen["argv"][1:]:
+                self.assertNotIn("\\", argument)
+            env = gesehen["kwargs"]["env"]
+            self.assertEqual(env["HERMES_HOME"], "C:/Users/emanu/AppData/Local/hermes")
+            self.assertEqual(
+                env["HERMES_AGENT_DIR"], "C:/Users/emanu/AppData/Local/hermes/hermes-agent"
+            )
+
+    def test_missing_bash_names_the_remedy(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "extensions" / "eurouter-provider"
+            src.mkdir(parents=True)
+            (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
+            with mock.patch.object(api, "_bash_binaer", return_value=None):
+                with self.assertRaises(api.HTTPException) as fall:
+                    api._run_bash_installer("eurouter-provider", src)
+            self.assertIn("git-scm.com", str(fall.exception.detail))
+
+    def test_ignores_the_wsl_launcher_in_system32(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            system32 = Path(tmp) / "Windows" / "System32"
+            system32.mkdir(parents=True)
+            wsl = system32 / "bash.exe"
+            wsl.write_text("")
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api.shutil, "which", return_value=str(wsl)):
+                self.assertIsNone(api._bash_binaer())
+
+    def test_uses_git_bash_when_it_exists(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            git_bash = Path(tmp) / "Git" / "bin" / "bash.exe"
+            git_bash.parent.mkdir(parents=True)
+            git_bash.write_text("")
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api.shutil, "which", return_value=None), \
+                    mock.patch.dict(api.os.environ, {"ProgramFiles": tmp}, clear=False):
+                self.assertEqual(api._bash_binaer(), str(git_bash))
+
+
+class VerfuegbarkeitTest(unittest.TestCase):
+    def test_hides_bash_only_component_on_windows_without_bash(self):
+        api = load_api_module()
+        with mock.patch.object(api, "_ist_windows", return_value=True), \
+                mock.patch.object(api, "_bash_binaer", return_value=None):
+            ok, grund, grund_en = api._verfuegbar("eurouter-provider")
+        self.assertFalse(ok)
+        self.assertIn("Bash", grund)
+        self.assertIn("bash", grund_en)
+
+    def test_native_components_stay_available_without_bash(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            hermes_heim(api, Path(tmp))
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api, "_bash_binaer", return_value=None):
+                for comp_id in ("german-language", "bot-mode-german", "group-chat-limits",
+                                "aiianer-backup"):
+                    ok, grund, _ = api._verfuegbar(comp_id)
+                    self.assertTrue(ok, f"{comp_id}: {grund}")
+
+
+class PayloadVorhandenTest(unittest.TestCase):
+    """Drift-Schutz: die nativen Installer kopieren Dateien beim Namen. Wird
+    eine umbenannt, muss dieser Test rot werden - nicht der Rechner eines
+    Community-Mitglieds."""
+
+    ERWARTET = {
+        "german-language": ("de.ts.gz", "apply-de.py"),
+        "bot-mode-german": ("de-bots.ts", "apply-bots-de.py"),
+        "group-chat-limits": (
+            "aiianer-group-limits.ts", "apply-limits.py", "gruppen-grenzen.beispiel.json",
+        ),
+        "aiianer-backup": ("backup_runner.py",),
+    }
+
+    def test_every_native_installer_finds_its_payload_in_the_repo(self):
+        api = load_api_module()
+        self.assertEqual(set(api.NATIVE_INSTALLER), set(self.ERWARTET))
+        for comp_id, dateien in self.ERWARTET.items():
+            ordner = REPO_ROOT / "extensions" / comp_id
+            self.assertTrue((ordner / "install.sh").is_file(), comp_id)
+            for name in dateien:
+                self.assertTrue((ordner / name).is_file(), f"{comp_id}/{name}")
+
+
+class InstallRouteAufWindowsTest(unittest.TestCase):
+    """Der Fall aus dem Fehlerbericht: Windows 11, Klick auf „Installieren“.
+
+    Früher lief das in einen HTTP 500 mit
+    "/bin/bash: C:\\Users\\...\\install.sh: No such file or directory".
+    Jetzt muss es durchlaufen - auch wenn auf dem Rechner gar keine Bash ist."""
+
+    def test_installs_german_language_end_to_end_without_any_bash(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+
+            # Ein "heruntergeladenes" Repo, wie _download es auspackt.
+            repo = wurzel / "aiianer-hermes-extensions-main"
+            src = repo / "extensions" / "german-language"
+            src.mkdir(parents=True)
+            with gzip.open(src / "de.ts.gz", "wb") as fh:
+                fh.write(b"export const de = {}\n")
+            (src / "apply-de.py").write_text(PATCHER_STUB)
+            (src / "install.sh").write_text("#!/usr/bin/env bash\nexit 7\n")
+
+            zustand: dict = {}
+            api._download = lambda _tmp: repo
+            api._load_catalog = lambda: {
+                "catalogVersion": "test",
+                "components": [{"id": "german-language", "version": "2026.09.01"}],
+            }
+            api._read_state = lambda: dict(zustand)
+            api._write_state = zustand.update
+            api._premium_berechtigt = lambda _entry: (True, "", "")
+
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api, "_bash_binaer", return_value=None):
+                antwort = asyncio.run(api.install({"id": "german-language"}))
+
+            self.assertTrue(antwort["ok"])
+            self.assertEqual(antwort["version"], "2026.09.01")
+            self.assertIn("Patcher gelaufen", antwort["log"])
+            # Payload liegt im Store UND unter ~/.hermes/aiianer/ fuer den Waechter.
+            self.assertTrue(
+                (heim / "aiianer-extensions" / "german-language" / "de.ts").is_file()
+            )
+            self.assertTrue((api.STATE_DIR / "de.ts").is_file())
+            self.assertTrue((api.STATE_DIR / "apply-de.py").is_file())
+
+    def test_install_route_reports_missing_bash_for_bash_only_component(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            hermes_heim(api, wurzel)
+            repo = wurzel / "aiianer-hermes-extensions-main"
+            src = repo / "extensions" / "eurouter-provider"
+            src.mkdir(parents=True)
+            (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
+
+            api._download = lambda _tmp: repo
+            api._load_catalog = lambda: {
+                "components": [{"id": "eurouter-provider", "version": "2.1.0"}]
+            }
+            api._read_state = lambda: {}
+            api._write_state = lambda _state: None
+            api._premium_berechtigt = lambda _entry: (True, "", "")
+
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api, "_bash_binaer", return_value=None):
+                with self.assertRaises(api.HTTPException) as fall:
+                    asyncio.run(api.install({"id": "eurouter-provider"}))
+            # 409 statt 500: die Pruefung greift, bevor irgendetwas laeuft.
+            self.assertEqual(fall.exception.status_code, 409)
+            self.assertIn("Bash", str(fall.exception.detail))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Der Fehler

Aus der Community (Windows 11, MSYS2-Bash 5.3.15): Klick auf **Installieren** bei „Deutsche Sprache" endete in einem HTTP 500.

```
/bin/bash: C:\Users\emanu\AppData\Local\Temp\tmp...\extensions\german-language\install.sh:
No such file or directory
```

Die Extension war in Ordnung — der Aufrufmechanismus nicht. `dashboard/plugin_api.py` rief:

```python
subprocess.run(["bash", str(installer)], ...)   # C:\Users\...\install.sh
```

Das schlägt unter Windows dreifach fehl:

1. **Ohne Bash** (die Mehrheit der Windows-Rechner) → nackter `WinError 2` → 500.
2. **Mit Git-/MSYS2-Bash** → der Backslash ist in der Bash ein Fluchtzeichen, aus `C:\Users\...` wird `C:Users...` → `No such file or directory` für eine Datei, die sehr wohl da liegt.
3. Und selbst nach einem reinen Pfad-Fix käme direkt der nächste Fehler: die `install.sh` startet **`python3`**, das es unter Windows nicht gibt.

Der Wächter (`guard_check.repair_*`) macht es längst richtig: nativ in Python mit `sys.executable`. Nur der Knopf im Marktplatz tat es nicht.

## Die Änderung

* **Windows installiert nativ.** „Deutsche Sprache", „Bot-Modus auf Deutsch", „Gruppenchat-Grenzen" und „AIIANER Backup" laufen über Python-Installer, die ihre `apply-*.py`-Patcher mit `sys.executable` starten — kein `bash`, kein `python3`, kein `gzip`, kein `cp` im PATH nötig. Dieselben Schritte, dieselbe Payload-Ablage (`$HERMES_HOME/aiianer-extensions/<id>`), dieselben Patcher-Argumente wie die `install.sh`.
* **Wo es weiter per Bash läuft** (EU-Router): relativer Dateiname `./install.sh` bei gesetztem `cwd`, dazu `HERMES_HOME` und `HERMES_AGENT_DIR` in Posix-Schreibweise. Ein Windows-Pfad erreicht die Bash nie mehr.
* **WSL-Falle geschlossen.** `shutil.which("bash")` findet unter Windows zuerst `C:\Windows\System32\bash.exe` — den WSL-Starter. Der sieht ein anderes Dateisystem: der Installer wäre scheinbar durchgelaufen und hätte am Hermes der Nutzerin nichts geändert. Gesucht werden jetzt Git-Bash und MSYS2, System32 wird übersprungen.
* **Kein Knopf, der zuverlässig in einen 500er läuft.** Fehlt eine Bash ganz, meldet der Katalog die betroffene Komponente vorher als nicht verfügbar und nennt Git for Windows als Abhilfe (409 statt 500).
* **Temp-Aufräumen kann die Installation nicht mehr als Fehler ausgeben.** Hält ein Virenscanner eine Datei fest, scheiterte bisher das `TemporaryDirectory`-Cleanup — eine gelungene Installation wurde als 500er angezeigt. Jetzt `shutil.rmtree(..., ignore_errors=True)`.
* **Die drei `install.sh`** suchen `python3` → `python` → `py`, damit auch ein Handstart in einer Git-Bash durchläuft.

## Nachweis

* **37 Tests grün** (18 bestehende + 19 neue in `tests/test_plugin_api_windows_install.py`), darunter die komplette `/install`-Route als Windows-Rechner **ohne jede Bash** — also genau der Fall aus dem Fehlerbericht.
* **Echter Durchlauf** des nativen Installers mit dem echten `apply-de.py` gegen einen nachgebauten Hermes-Checkout: Ergebnis identisch zum manuellen Erfolg des Melders (`OK: Deutsche Sprachdatei neu verdrahtet`), `types.ts`/`catalog.ts`/`languages.ts` verdrahtet, `de.ts` (190 KB) kopiert, `.aiianer-orig`/`.aiianer-bak` intakt, zweiter Lauf idempotent.
* **Bash-Weg unter Linux** ebenfalls echt durchlaufen — keine Regression für bestehende macOS- und Linux-Nutzer.
* **Drift-Schutz:** ein Test prüft, dass jeder native Installer seine Payload-Dateien im Repo findet (schlägt bei einer Umbenennung hier an statt auf einem Community-Rechner), ein zweiter, dass `plugin.yaml`, `dashboard/manifest.json` und `catalog.json` dieselbe Hub-Version tragen.

Nicht getestet: eine echte Windows-Maschine stand nicht zur Verfügung. Die Plattform-Weiche liegt deshalb in einer Funktion (`_ist_windows`), die die Tests umschalten.

## Für betroffene Nutzer

Der Hub aktualisiert sich selbst nativ in Python und war von dem Fehler **nicht** betroffen. Der Weg heraus ist deshalb: erst **AIIANER EXTENSION HUB** aktualisieren (1.3.33), dann die gewünschte Komponente installieren.

## Offen

Der **EU-Router** bringt weiter einen Bash-Installer mit, weil er seinen kanonischen Installer per `curl` aus `hermes-eurouter-plugin` nachlädt. Unter Windows braucht er daher eine Bash — sagt das aber jetzt vorher, statt beim Klick zu scheitern. Wird separat nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhTistGFwvS5Ndmh3xgGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqhTistGFwvS5Ndmh3xgGa)_