### PR TITLE
fix: EU-Router unter Windows ohne Bash installieren (Hub 1.3.34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,12 @@ Kommst du von 1.3.32 oder älter und die Installation endete mit
 Marktplatz den **AIIANER EXTENSION HUB** aktualisieren, danach die gewünschte
 Komponente. Das Hub-Update selbst war von dem Fehler nicht betroffen.
 
-Nur der **EU-Router** bringt weiter einen Bash-Installer mit. Fehlt eine Bash,
-sagt der Marktplatz das vorher und nennt
+Seit 1.3.34 gilt das auch für den **EU-Router**: der Marktplatz baut die
+Schritte seines Installers nativ nach, statt sein Shell-Skript auszuführen. Auf
+Linux und macOS läuft weiterhin das Original-Skript aus dem EU-Router-Repo.
+
+Sollte künftig eine Komponente doch einmal eine Bash brauchen, sagt der
+Marktplatz das **vorher** und nennt
 [Git for Windows](https://git-scm.com/download/win) als Abhilfe, statt beim
 Klick in einen Fehler zu laufen.
 

--- a/catalog.json
+++ b/catalog.json
@@ -6,7 +6,7 @@
     {
       "id": "aiianer-hub",
       "name": "AIIANER EXTENSION HUB",
-      "version": "1.3.33",
+      "version": "1.3.34",
       "kind": "plugin",
       "premium": false,
       "summary": "Der Marktplatz selbst. Aktualisiert Oberfläche, Desktop-Plugin, Backend und Wächter in einem Schritt.",

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "AIIANER EXTENSION HUB",
   "description": "Deutsche Erweiterungen installieren und aktuell halten",
   "icon": "Package",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "tab": {
     "path": "/aiianer",
     "position": "after:skills"

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -32,6 +32,11 @@ router = APIRouter()
 
 REPO = "oliverhees/aiianer-hermes-extensions"
 TARBALL = f"https://github.com/{REPO}/archive/refs/heads/main.tar.gz"
+# Der EU-Router wohnt in einem eigenen Repo. Sein install.sh ist der
+# kanonische Weg; der native Windows-Weg unten holt denselben Stand als
+# Tarball, weil es dort keine Bash gibt, die das Skript ausfuehren koennte.
+EUROUTER_REPO = "oliverhees/hermes-eurouter-plugin"
+EUROUTER_TARBALL = f"https://github.com/{EUROUTER_REPO}/archive/refs/heads/main.tar.gz"
 CATALOG_URL = f"https://raw.githubusercontent.com/{REPO}/main/catalog.json"
 RELEASES_URL = f"https://api.github.com/repos/{REPO}/releases"
 ROADMAP_URL = f"https://raw.githubusercontent.com/{REPO}/main/roadmap.json"
@@ -114,6 +119,7 @@ NEXT_STEPS = {
     },
     "eurouter-provider": {
         "install": [
+            "EUROUTER_API_KEY in die Datei .env im Hermes-Verzeichnis eintragen, falls noch nicht geschehen.",
             "Hermes komplett beenden und neu starten.",
             "Der EU-Router taucht dann im Modell-Auswahlmenü als eigene Gruppe auf.",
         ],
@@ -1016,14 +1022,81 @@ def _install_backup_native(src: Path) -> list[str]:
     ]
 
 
-# Nur Erweiterungen, deren install.sh nichts anderes tut als Payload ablegen
-# und einen Patcher starten. Der EU-Router laedt einen fremden Installer aus
-# dem Netz nach - den kann und soll dieser Code nicht nachbauen.
+def _eurouter_cache_leeren() -> list[str]:
+    """Der Modell-Listen-Cache hat eine Stunde TTL. Bleibt der alte Eintrag
+    stehen, wirkt ein Update bis zu einer Stunde lang "wie nicht passiert"."""
+    cache = HERMES_HOME / "provider_models_cache.json"
+    if not cache.is_file():
+        return []
+    try:
+        daten = json.loads(cache.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(daten, dict) or daten.pop("eurouter", None) is None:
+        return []
+    _write_json_atomic(cache, daten)
+    return ["Modell-Listen-Cache für eurouter geleert."]
+
+
+def _install_eurouter_native(_src: Path) -> list[str]:
+    """Schritte aus install.sh des EU-Router-Repos, ohne Bash.
+
+    Das Skript dort ist der kanonische Weg und bleibt es auf Linux und macOS.
+    Es tut genau drei Dinge, die hier nachgebaut sind: die beiden
+    Provider-Dateien nach $HERMES_HOME/plugins/model-providers/eurouter
+    kopieren, ein altes __pycache__ wegräumen und den Modell-Listen-Cache
+    leeren. Der Shim unter ~/.local/bin/hermes gehoert NICHT dazu - den
+    installiert nur '--with-shim', und der Marktplatz ruft ohne Argumente auf.
+
+    Die Payload liegt im EU-Router-Repo, nicht in diesem hier. Sie wird
+    deshalb frisch geladen - derselbe Stand, den auch das install.sh zieht."""
+    if not HERMES_HOME.is_dir():
+        raise HTTPException(
+            status_code=500,
+            detail=f"{HERMES_HOME} existiert nicht. Ist Hermes installiert?",
+        )
+    tmp = tempfile.mkdtemp(prefix="aiianer-eurouter-")
+    try:
+        try:
+            wurzel = _download_tarball(EUROUTER_TARBALL, tmp)
+        except HTTPException:
+            raise
+        except OSError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"EU-Router konnte nicht geladen werden: {exc}",
+            ) from exc
+        quelle = wurzel / "model-providers" / "eurouter"
+        dateien = ("__init__.py", "plugin.yaml")
+        fehlend = [n for n in dateien if not (quelle / n).is_file()]
+        if fehlend:
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "Das EU-Router-Repo ist unvollständig, es fehlt: "
+                    + ", ".join(fehlend)
+                ),
+            )
+        ziel = PLUGINS / "model-providers" / "eurouter"
+        ziel.mkdir(parents=True, exist_ok=True)
+        for name in dateien:
+            _atomic_copy(quelle / name, ziel / name)
+        # Ein altes __pycache__ kann eine ersetzte Datei ueberleben.
+        shutil.rmtree(ziel / "__pycache__", ignore_errors=True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return [f"EU-Router-Plugin installiert nach {ziel}"] + _eurouter_cache_leeren()
+
+
+# Erweiterungen, die ohne Bash installiert werden koennen. Jede Funktion hier
+# baut die Schritte der zugehoerigen install.sh nach - nicht mehr und nicht
+# weniger.
 NATIVE_INSTALLER = {
     "german-language": _install_german_native,
     "bot-mode-german": _install_bots_native,
     "group-chat-limits": _install_limits_native,
     "aiianer-backup": _install_backup_native,
+    "eurouter-provider": _install_eurouter_native,
 }
 
 
@@ -1533,10 +1606,16 @@ async def repair() -> dict:
 # ---------------------------------------------------------------- Helfer
 
 def _download(tmp: str) -> Path:
+    return _download_tarball(TARBALL, tmp)
+
+
+def _download_tarball(url: str, tmp: str) -> Path:
+    """Laedt einen GitHub-Tarball und packt ihn aus. Eine Stelle fuer alle
+    Downloads, damit der Tar-Slip-Schutz unten nicht irgendwo fehlt."""
     archive = Path(tmp) / "repo.tar.gz"
     # Ohne Timeout haengt der Download unbegrenzt und blockiert damit die
     # ganze Route.
-    with urllib.request.urlopen(TARBALL, timeout=60) as resp, open(archive, "wb") as fh:
+    with urllib.request.urlopen(url, timeout=60) as resp, open(archive, "wb") as fh:
         shutil.copyfileobj(resp, fh)
     # filter="data" verhindert Tar-Slip (Pfade ausserhalb des Zielordners,
     # Symlinks, absolute Pfade). Vor Python 3.14 ist das NICHT die

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: aiianer-hub
 manifest_version: 1
-version: 1.3.33
+version: 1.3.34
 description: >
   AIIANER Marktplatz. Installiert und aktualisiert die deutschen
   Hermes-Erweiterungen und haelt die Sprachdatei nach jedem Update aktuell.

--- a/releases.json
+++ b/releases.json
@@ -1,6 +1,12 @@
 {
   "releases": [
     {
+      "tagName": "v1.3.34",
+      "name": "v1.3.34 · EU-Router auch ohne Bash",
+      "publishedAt": "2026-09-12T10:00:00Z",
+      "body": "Die letzte Komponente, die unter Windows eine Bash brauchte, kommt jetzt ohne aus. Der Marktplatz baut die Schritte des kanonischen EU-Router-Installers nativ nach: Provider-Dateien nach plugins/model-providers/eurouter kopieren, ein altes __pycache__ wegräumen, den Modell-Listen-Cache leeren. Auf Linux und macOS läuft weiterhin das Original-Skript aus dem EU-Router-Repo. Außerdem nennt der Marktplatz den Schritt mit dem EUROUTER_API_KEY jetzt in den nächsten Schritten - er stand bisher nur in der Ausgabe des Installers."
+    },
+    {
       "tagName": "v1.3.33",
       "name": "v1.3.33 · Installation unter Windows repariert",
       "publishedAt": "2026-09-12T08:00:00Z",

--- a/tests/test_plugin_api_hub_install.py
+++ b/tests/test_plugin_api_hub_install.py
@@ -273,8 +273,12 @@ class HubCatalogUpdateStatusTest(unittest.TestCase):
             result = asyncio.run(api.catalog())
 
         hub = next(component for component in result["components"] if component["id"] == "aiianer-hub")
+        # Die Soll-Version kommt aus dem Katalog selbst - eine fest
+        # eingetippte Zahl hier waere bei jedem Release ein falscher Alarm.
+        katalog = json.loads((REPO_ROOT / "catalog.json").read_text())
+        soll = next(c["version"] for c in katalog["components"] if c["id"] == "aiianer-hub")
         self.assertEqual(hub["installed"], "1.3.12")
-        self.assertEqual(hub["version"], "1.3.33")
+        self.assertEqual(hub["version"], soll)
         self.assertEqual(hub["status"], "outdated")
 
 

--- a/tests/test_plugin_api_windows_install.py
+++ b/tests/test_plugin_api_windows_install.py
@@ -259,7 +259,7 @@ class BashAufrufTest(unittest.TestCase):
 
             with mock.patch.object(api, "_bash_binaer", return_value="/usr/bin/bash"), \
                     mock.patch.object(api.subprocess, "run", falscher_lauf):
-                api._run_bash_installer("eurouter-provider", src)
+                api._run_bash_installer("kuenftige-komponente", src)
 
             self.assertEqual(gesehen["argv"], ["/usr/bin/bash", "./install.sh"])
             self.assertEqual(Path(gesehen["kwargs"]["cwd"]), src)
@@ -280,7 +280,7 @@ class BashAufrufTest(unittest.TestCase):
             (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
             with mock.patch.object(api, "_bash_binaer", return_value=None):
                 with self.assertRaises(api.HTTPException) as fall:
-                    api._run_bash_installer("eurouter-provider", src)
+                    api._run_bash_installer("kuenftige-komponente", src)
             self.assertIn("git-scm.com", str(fall.exception.detail))
 
     def test_ignores_the_wsl_launcher_in_system32(self):
@@ -311,7 +311,7 @@ class VerfuegbarkeitTest(unittest.TestCase):
         api = load_api_module()
         with mock.patch.object(api, "_ist_windows", return_value=True), \
                 mock.patch.object(api, "_bash_binaer", return_value=None):
-            ok, grund, grund_en = api._verfuegbar("eurouter-provider")
+            ok, grund, grund_en = api._verfuegbar("kuenftige-komponente")
         self.assertFalse(ok)
         self.assertIn("Bash", grund)
         self.assertIn("bash", grund_en)
@@ -323,7 +323,7 @@ class VerfuegbarkeitTest(unittest.TestCase):
             with mock.patch.object(api, "_ist_windows", return_value=True), \
                     mock.patch.object(api, "_bash_binaer", return_value=None):
                 for comp_id in ("german-language", "bot-mode-german", "group-chat-limits",
-                                "aiianer-backup"):
+                                "aiianer-backup", "eurouter-provider"):
                     ok, grund, _ = api._verfuegbar(comp_id)
                     self.assertTrue(ok, f"{comp_id}: {grund}")
 
@@ -340,6 +340,9 @@ class PayloadVorhandenTest(unittest.TestCase):
             "aiianer-group-limits.ts", "apply-limits.py", "gruppen-grenzen.beispiel.json",
         ),
         "aiianer-backup": ("backup_runner.py",),
+        # Der EU-Router bringt seine Payload aus einem eigenen Repo mit, hier
+        # liegt nur der Installer. Geprueft wird deshalb nur dessen Existenz.
+        "eurouter-provider": (),
     }
 
     def test_every_native_installer_finds_its_payload_in_the_repo(self):
@@ -404,13 +407,13 @@ class InstallRouteAufWindowsTest(unittest.TestCase):
             wurzel = Path(tmp)
             hermes_heim(api, wurzel)
             repo = wurzel / "aiianer-hermes-extensions-main"
-            src = repo / "extensions" / "eurouter-provider"
+            src = repo / "extensions" / "kuenftige-komponente"
             src.mkdir(parents=True)
             (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
 
             api._download = lambda _tmp: repo
             api._load_catalog = lambda: {
-                "components": [{"id": "eurouter-provider", "version": "2.1.0"}]
+                "components": [{"id": "kuenftige-komponente", "version": "1.0.0"}]
             }
             api._read_state = lambda: {}
             api._write_state = lambda _state: None
@@ -419,10 +422,102 @@ class InstallRouteAufWindowsTest(unittest.TestCase):
             with mock.patch.object(api, "_ist_windows", return_value=True), \
                     mock.patch.object(api, "_bash_binaer", return_value=None):
                 with self.assertRaises(api.HTTPException) as fall:
-                    asyncio.run(api.install({"id": "eurouter-provider"}))
+                    asyncio.run(api.install({"id": "kuenftige-komponente"}))
             # 409 statt 500: die Pruefung greift, bevor irgendetwas laeuft.
             self.assertEqual(fall.exception.status_code, 409)
             self.assertIn("Bash", str(fall.exception.detail))
+
+
+class NativeEurouterTest(unittest.TestCase):
+    """Der EU-Router wohnt in einem eigenen Repo. Unter Windows wird sein
+    install.sh nachgebaut, statt eine Bash zu verlangen."""
+
+    def eurouter_repo(self, wurzel: Path) -> Path:
+        repo = wurzel / "hermes-eurouter-plugin-main"
+        quelle = repo / "model-providers" / "eurouter"
+        quelle.mkdir(parents=True)
+        (quelle / "__init__.py").write_text("# eurouter provider\n")
+        (quelle / "plugin.yaml").write_text("name: eurouter\nversion: 2.1.0\n")
+        return repo
+
+    def test_installs_provider_files_and_clears_the_model_cache(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            api.PLUGINS = heim / "plugins"
+            repo = self.eurouter_repo(wurzel)
+
+            # Ein Cache mit fremden Eintraegen - die muessen stehen bleiben.
+            cache = heim / "provider_models_cache.json"
+            cache.write_text(json.dumps({"eurouter": ["alt"], "openai": ["bleibt"]}))
+
+            # Ein altes __pycache__, das ein Update ueberleben wuerde.
+            alt = api.PLUGINS / "model-providers" / "eurouter" / "__pycache__"
+            alt.mkdir(parents=True)
+            (alt / "__init__.cpython-311.pyc").write_text("stale")
+
+            with mock.patch.object(api, "_download_tarball", return_value=repo):
+                log = api._install_eurouter_native(wurzel / "egal")
+
+            ziel = api.PLUGINS / "model-providers" / "eurouter"
+            self.assertEqual((ziel / "__init__.py").read_text(), "# eurouter provider\n")
+            self.assertTrue((ziel / "plugin.yaml").is_file())
+            self.assertFalse((ziel / "__pycache__").exists())
+            self.assertEqual(json.loads(cache.read_text()), {"openai": ["bleibt"]})
+            self.assertTrue(any("Cache" in z for z in log), log)
+
+    def test_reports_incomplete_remote_repo(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            api.PLUGINS = heim / "plugins"
+            repo = wurzel / "hermes-eurouter-plugin-main"
+            (repo / "model-providers" / "eurouter").mkdir(parents=True)
+            with mock.patch.object(api, "_download_tarball", return_value=repo):
+                with self.assertRaises(api.HTTPException) as fall:
+                    api._install_eurouter_native(wurzel / "egal")
+            self.assertIn("__init__.py", str(fall.exception.detail))
+
+    def test_says_it_plainly_when_hermes_home_is_missing(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            api.HERMES_HOME = Path(tmp) / "gibt-es-nicht"
+            with self.assertRaises(api.HTTPException) as fall:
+                api._install_eurouter_native(Path(tmp))
+            self.assertIn("Ist Hermes installiert", str(fall.exception.detail))
+
+    def test_windows_never_reaches_for_bash(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            wurzel = Path(tmp)
+            heim = hermes_heim(api, wurzel)
+            api.PLUGINS = heim / "plugins"
+            repo = self.eurouter_repo(wurzel)
+            with mock.patch.object(api, "_ist_windows", return_value=True), \
+                    mock.patch.object(api, "_download_tarball", return_value=repo), \
+                    mock.patch.object(
+                        api, "_run_bash_installer",
+                        side_effect=AssertionError("bash darf nicht laufen")):
+                api._run_extension_installer("eurouter-provider", wurzel / "egal")
+            self.assertTrue(
+                (api.PLUGINS / "model-providers" / "eurouter" / "plugin.yaml").is_file()
+            )
+
+    def test_posix_keeps_the_canonical_shell_installer(self):
+        api = load_api_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "extensions" / "eurouter-provider"
+            src.mkdir(parents=True)
+            (src / "install.sh").write_text("#!/usr/bin/env bash\necho ok\n")
+            with mock.patch.object(api, "_ist_windows", return_value=False), \
+                    mock.patch.object(
+                        api, "_run_bash_installer", return_value=["ok"]) as bash_weg:
+                self.assertEqual(
+                    api._run_extension_installer("eurouter-provider", src), ["ok"]
+                )
+            bash_weg.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Folgt auf #3. Dort wurden „Deutsche Sprache", „Bot-Modus auf Deutsch", „Gruppenchat-Grenzen" und „AIIANER Backup" unter Windows nativ gemacht. Der **EU-Router** blieb übrig: sein Installer lädt per `curl` das kanonische Skript aus `hermes-eurouter-plugin` nach, brauchte also weiter eine Bash.

## Die Änderung

Das Skript dort tut genau drei Dinge, die jetzt nativ nachgebaut sind:

1. `model-providers/eurouter/__init__.py` und `plugin.yaml` nach `$HERMES_HOME/plugins/model-providers/eurouter` kopieren (atomar, über den bestehenden `_atomic_copy`),
2. ein altes `__pycache__` wegräumen — das kann eine ersetzte Datei überleben,
3. den Eintrag `eurouter` aus `provider_models_cache.json` entfernen. Der Cache hat eine Stunde TTL; bleibt der alte Eintrag stehen, wirkt ein Update bis zu einer Stunde lang „wie nicht passiert".

Der Shim unter `~/.local/bin/hermes` gehört ausdrücklich **nicht** dazu: den installiert nur `--with-shim`, und der Marktplatz ruft ohne Argumente auf. Das deckt sich mit dem bestehenden Rückbau, der den Shim bewusst liegen lässt.

Auf Linux und macOS läuft weiterhin das kanonische Skript aus dem EU-Router-Repo — dort ändert sich nichts. Der Windows-Weg lädt denselben Stand als Tarball. Dafür ist `_download` in `_download_tarball(url, tmp)` aufgeteilt, damit es weiter nur **eine** Stelle mit dem Tar-Slip-Schutz (`filter="data"`) gibt.

**Nebenbei gefunden:** Der Schritt „`EUROUTER_API_KEY` in die `.env` eintragen" stand bisher nur in der Ausgabe des Shell-Installers. Wer den nativen Weg geht, hätte ihn nie gesehen. Er steht jetzt in den nächsten Schritten — für alle Plattformen.

## Nachweis

* **42 Tests grün** (5 neue): Kopie der Provider-Dateien, gezieltes Leeren des Caches (fremde Provider-Einträge bleiben stehen), altes `__pycache__` verschwindet, unvollständiges Remote-Repo wird benannt statt zu crashen, fehlendes `HERMES_HOME` wird benannt, unter Windows wird nie nach einer Bash gegriffen, und auf Posix bleibt der Bash-Weg der genommene.
* **Echter Durchlauf** gegen einen echten Clone von `hermes-eurouter-plugin`: beide Dateien kopiert (`plugin.yaml` → `name: eurouter-provider`, `version: 2.1.0`), Cache-Eintrag `eurouter` weg, `anthropic` unangetastet — und der bestehende `_uninstall_eurouter` räumt genau diesen Pfad wieder ab.
* Der Drift-Test aus #3 hat beim Hinzufügen zugeschlagen (der EU-Router hat keine lokale Payload) und ist entsprechend nachgezogen: geprüft wird hier nur, dass sein Installer existiert.
* Die fest eingetippte Hub-Version im Katalog-Test ist raus — sie kommt jetzt aus `catalog.json` selbst, sonst ist sie bei jedem Release ein falscher Alarm.

Damit braucht unter Windows **keine** Komponente mehr eine Bash. Sollte künftig doch eine dazukommen, greift weiter die Vorab-Prüfung aus #3: der Katalog meldet sie als nicht verfügbar und nennt Git for Windows, statt beim Klick in einen 500er zu laufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhTistGFwvS5Ndmh3xgGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqhTistGFwvS5Ndmh3xgGa)_